### PR TITLE
ci: remove unused build-pr job from workflow

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -49,37 +49,6 @@ jobs:
           name: coverage
           path: coverage.out
 
-  build-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    needs: [test]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: true
-
-      - name: Build and push PR image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: openmeet-ecr/survey
-          IMAGE_TAG: pr-${{ github.event.pull_request.number }}
-        run: |
-          echo "Building PR image: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
   build-and-deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
Remove the `build-pr` job that was blocking fork PRs from getting green CI.

## Problem
- Fork PRs can't access repository secrets (GitHub security feature)
- The `build-pr` job requires AWS credentials to push images to ECR
- Result: All fork PRs fail CI even when tests pass

## Solution
Remove `build-pr` entirely. It pushed PR images that were never used (no preview deployments exist).

## What remains
- **PRs**: Run `test` job only (build, lint, unit tests)
- **Main merges**: Run `build-and-deploy` + `gitops-update`

## Test plan
- [x] Verify workflow YAML is valid
- [ ] Merge and confirm PR #4 CI passes